### PR TITLE
Retarget

### DIFF
--- a/src/TooLazyForGenerators/CompatibilityExtensions.cs
+++ b/src/TooLazyForGenerators/CompatibilityExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace TooLazyForGenerators;
+
+/// <summary>
+/// Extensions for compatibility between .NET Standard 2.0 and the latest language version.
+/// </summary>
+internal static class CompatibilityExtensions
+{
+    public static void Deconstruct<TKey, TValue>(
+        this KeyValuePair<TKey, TValue> pair,
+        out TKey key,
+        out TValue value)
+    {
+        key = pair.Key;
+        value = pair.Value;
+    }
+}

--- a/src/TooLazyForGenerators/GeneratorOutputRunner.cs
+++ b/src/TooLazyForGenerators/GeneratorOutputRunner.cs
@@ -58,8 +58,10 @@ internal sealed class GeneratorOutputRunner
         
         var ctor = type.GetConstructor(
             BindingFlags.Instance | BindingFlags.Public,
-            Array.Empty<Type>());
-
+            null,
+            Array.Empty<Type>(),
+            null);
+        
         if (ctor is null)
             throw new InvalidOperationException($"{type.FullName} has no public parameterless constructor.");
 

--- a/src/TooLazyForGenerators/TooLazyForGenerators.csproj
+++ b/src/TooLazyForGenerators/TooLazyForGenerators.csproj
@@ -1,7 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <!-- MSBuild packages do not support netstandard2.0, therefore have to multitarget. -->
+    <TargetFrameworks>net472;netcoreapp3.1</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -10,8 +12,15 @@
     <PackageReference Include="Microsoft.Build.Locator" Version="1.5.5" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.5.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="7.0.0" />
+    <!-- Version 7.0.0 of these packages do not support net472. -->
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    
+    <!-- Polyfills for newer language features. -->
+    <PackageReference Include="PolySharp" Version="1.13.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Retarget to .NET Framework 4.7.2 and .NET Core 3.1 for compatibility with MSBuild tasks.